### PR TITLE
chore: Retrieve latest cerbos version from github releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ An example application of integrating [Cerbos](https://cerbos.dev) with an [Expr
 ## Dependencies
 
 - Node.js
-- Docker for running the [Cerbos Policy Decision Point (PDP)](https://docs.cerbos.dev/cerbos/0.6.0/installation/container.html)
+- Docker for running the [Cerbos Policy Decision Point (PDP)](https://docs.cerbos.dev/cerbos/latest/installation/container.html)
 - An Auth0 account if you want to use your own
 
 ## Getting Started

--- a/cerbos/Dockerfile
+++ b/cerbos/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/cerbos/cerbos:0.7.0-amd64
+FROM ghcr.io/cerbos/cerbos:0.10.0
 COPY policies /policies
 COPY config /config
 ENTRYPOINT ["/cerbos"]

--- a/cerbos/start.sh
+++ b/cerbos/start.sh
@@ -1,5 +1,7 @@
+LATEST_VERSION=$(curl --silent "https://api.github.com/repos/cerbos/cerbos/releases/latest" | jq -r .tag_name)
+
 docker run -i -t -p 3592:3592 \
   -v $(pwd)/config:/config \
   -v $(pwd)/policies:/policies \
-  ghcr.io/cerbos/cerbos:0.7.0 \
+  ghcr.io/cerbos/cerbos:"${LATEST_VERSION:1}" \
   server --config=/config/conf.yaml


### PR DESCRIPTION
Signed-off-by: Oğuzhan D <oguzhandurgun95@gmail.com>

#### Description

Retrieves the latest release from GitHub API to use in scripts.

#### Checklist 

- [x] The PR title has the correct prefix 
- [x] PR is linked to the corresponding issue
- [x] All commits are signed-off (`git commit -s ...`) to provide the [DCO](https://developercertificate.org/)
